### PR TITLE
Theres no logoBadge so use logo.svg to get a "browser tab icon"

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <!-- End Google Tag -->
 
 		<title>Salmon Arm Jiu-Jitsu | Home</title>
-		<link rel = "icon" type = "image/x-icon" href = "images/index/logoBadge.png">
+		<link rel = "icon" type = "image/x-icon" href = "images/logo/logo.svg">
 		<meta charset = "utf-8" />
         <meta name = "viewport" content = "width = device-width, initial-scale = 1, user-scalable = yes" />
 		<link rel = "stylesheet" href = "assets/css/style.css" />


### PR DESCRIPTION
There's no logoBadge so use logo.svg to get a "browser tab icon"
Or add back in logoBadge.png

![image](https://github.com/user-attachments/assets/2f3b834e-3077-4ba2-bc82-2386718be374)
